### PR TITLE
Bug fix: Edit command resets person's delivery status + attempts

### DIFF
--- a/src/main/java/bookopedia/logic/commands/EditCommand.java
+++ b/src/main/java/bookopedia/logic/commands/EditCommand.java
@@ -95,7 +95,8 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Parcel> updatedParcels = editPersonDescriptor.getParcels().orElse(personToEdit.getParcels());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedParcels);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedParcels,
+                personToEdit.getDeliveryStatus(), personToEdit.getNoOfDeliveryAttempts());
     }
 
     @Override

--- a/src/main/java/bookopedia/logic/parser/AddCommandParser.java
+++ b/src/main/java/bookopedia/logic/parser/AddCommandParser.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 
 import bookopedia.logic.commands.AddCommand;
 import bookopedia.logic.parser.exceptions.ParseException;
+import bookopedia.model.DeliveryStatus;
 import bookopedia.model.parcel.Parcel;
 import bookopedia.model.person.Address;
 import bookopedia.model.person.Email;
@@ -54,7 +55,7 @@ public class AddCommandParser implements Parser<AddCommand> {
             email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         }
 
-        Person person = new Person(name, phone, email, address, parcelList);
+        Person person = new Person(name, phone, email, address, parcelList, DeliveryStatus.PENDING, 0);
 
         return new AddCommand(person);
     }

--- a/src/main/java/bookopedia/model/person/Person.java
+++ b/src/main/java/bookopedia/model/person/Person.java
@@ -42,20 +42,6 @@ public class Person {
         this.noOfDeliveryAttempts = noOfDeliveryAttempts;
     }
 
-    /**
-     * Every field must be present and not null except phone and email.
-     * Pending delivery status assigned by default.
-     */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Parcel> parcels) {
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
-        this.parcels.addAll(parcels);
-        this.deliveryStatus = DeliveryStatus.PENDING;
-        this.noOfDeliveryAttempts = 0;
-    }
-
     public Name getName() {
         return name;
     }

--- a/src/main/java/bookopedia/model/util/SampleDataUtil.java
+++ b/src/main/java/bookopedia/model/util/SampleDataUtil.java
@@ -31,13 +31,13 @@ public class SampleDataUtil {
                 getParcelSet("shopee"), DeliveryStatus.FAILED, 0),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getParcelSet("alibaba")),
+                getParcelSet("alibaba"), DeliveryStatus.PENDING, 0),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getParcelSet("grab")),
+                getParcelSet("grab"), DeliveryStatus.PENDING, 0),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getParcelSet("amazon"))
+                getParcelSet("amazon"), DeliveryStatus.PENDING, 0)
         };
     }
 


### PR DESCRIPTION
Closes #80.

EditCommand uses the overloaded constructor without the delivery status and no of attempts which causes Person edited to reset these values to its default values. Removing the overloaded constructor makes it explicit to set the delivery status and no of attempts, and also fix the edit command bug.