### PR TITLE
Add return delivery status

### DIFF
--- a/src/main/java/bookopedia/model/DeliveryStatus.java
+++ b/src/main/java/bookopedia/model/DeliveryStatus.java
@@ -4,8 +4,18 @@ package bookopedia.model;
  * Delivery status.
  */
 public enum DeliveryStatus {
-    PENDING, OTW, DONE, FAILED;
+    PENDING, OTW, DONE, FAILED, RETURN;
+
+    public static final int NO_OF_ATTEMPTS_BEFORE_RETURN = 3;
 
     public static final String MESSAGE_CONSTRAINTS = "Delivery status must be of the following: "
             + "pending, otw, done, failed";
+
+    public static final String MESSAGE_CONSTRAINTS_NEGATIVE_ATTEMPTS = "No. of delivery attempts cannot be negative!";
+
+    public static final String MESSAGE_CONSTRAINTS_RETURN_ATTEMPTS = String.format("No. of delivery attempts cannot "
+            + "be more than 'no. of attempts before return' which is %d!", NO_OF_ATTEMPTS_BEFORE_RETURN);
+
+    public static final String MESSAGE_CONSTRAINTS_RETURN_MISMATCH = String.format("No. of delivery attempts is equal "
+            + "to the 'no.of attempts before return' but the status is not RETURN", NO_OF_ATTEMPTS_BEFORE_RETURN);
 }

--- a/src/main/java/bookopedia/storage/JsonAdaptedPerson.java
+++ b/src/main/java/bookopedia/storage/JsonAdaptedPerson.java
@@ -143,7 +143,14 @@ class JsonAdaptedPerson {
         final Set<Parcel> modelParcels = new HashSet<>(personParcels);
 
         if (noOfDeliveryAttempts < 0) {
-            throw new IllegalValueException("No. of delivery attempts cannot be negative!");
+            throw new IllegalValueException(DeliveryStatus.MESSAGE_CONSTRAINTS_NEGATIVE_ATTEMPTS);
+        } else if (noOfDeliveryAttempts > DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN) {
+            throw new IllegalValueException(DeliveryStatus.MESSAGE_CONSTRAINTS_RETURN_ATTEMPTS);
+        }
+
+        if (noOfDeliveryAttempts == DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN
+                && modelDeliveryStatus != DeliveryStatus.RETURN) {
+            throw new IllegalValueException(DeliveryStatus.MESSAGE_CONSTRAINTS_RETURN_MISMATCH);
         }
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelParcels,

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -459,6 +459,10 @@
     -fx-background-color: darkred;
 }
 
+#deliveryStatus.RETURN {
+    -fx-background-color: purple;
+}
+
 #deliveryStatusToView.OTW {
     -fx-background-color: orange;
 }
@@ -473,6 +477,10 @@
 
 #deliveryStatusToView.FAILED {
     -fx-background-color: darkred;
+}
+
+#deliveryStatusToView.RETURN {
+    -fx-background-color: purple;
 }
 
 #noOfDeliveryAttempts {

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -5,6 +5,6 @@
     "email": "invalid@email!3e",
     "address": "4th street",
     "deliveryStatus": "PENDING",
-    "noOfDeliveryAttempts": 0
+    "noOfDeliveryAttempts": 10
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -68,7 +68,7 @@
     "parcels" : [ ],
     "parcelsIsFragile" : [ ],
     "parcelsIsBulky" : [ ],
-    "deliveryStatus": "PENDING",
+    "deliveryStatus": "FAILED",
     "noOfDeliveryAttempts": 0
   } ]
 }

--- a/src/test/java/bookopedia/logic/commands/MarkCommandTest.java
+++ b/src/test/java/bookopedia/logic/commands/MarkCommandTest.java
@@ -3,6 +3,7 @@ package bookopedia.logic.commands;
 import static bookopedia.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandFailure;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static bookopedia.logic.commands.MarkCommand.MESSAGE_RETURN_STATUS_CHANGED;
 import static bookopedia.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static bookopedia.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -95,6 +96,130 @@ public class MarkCommandTest {
                 INDEX_FIRST_PERSON.getZeroBased()), updatedPersonToMark);
 
         assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_markReturn_success() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.RETURN;
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPersonToMark = new PersonBuilder(personToMark).withDeliveryStatus(deliveryStatus).build();
+
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, deliveryStatus);
+        String expectedMessage = String.format(MarkCommand.MESSAGE_SUCCESS, personToMark.getName(), deliveryStatus);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(
+                INDEX_FIRST_PERSON.getZeroBased()), updatedPersonToMark);
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_markFailedHitNoOfAttemptBeforeReturn_changeStatusToReturn() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.FAILED;
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person newPersonToMark = new PersonBuilder(personToMark)
+                .withDeliveryStatus(DeliveryStatus.OTW)
+                .withNoOfDeliveryAttempts(DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN - 1)
+                .build();
+        Person updatedPersonToMark = new PersonBuilder(personToMark)
+                .withDeliveryStatus(DeliveryStatus.RETURN)
+                .withNoOfDeliveryAttempts(DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN)
+                .build();
+
+        model.setPerson(personToMark, newPersonToMark);
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, deliveryStatus);
+        String expectedMessage = String.format(MarkCommand.MESSAGE_SUCCESS, personToMark.getName(),
+                DeliveryStatus.FAILED);
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
+                new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(
+                INDEX_FIRST_PERSON.getZeroBased()), updatedPersonToMark);
+
+        assertCommandSuccess(markCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_markOtwOnReturnedDelivery_failed() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.OTW;
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPersonToMark = new PersonBuilder(personToMark)
+                .withDeliveryStatus(DeliveryStatus.RETURN)
+                .withNoOfDeliveryAttempts(DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN)
+                .build();
+
+        model.setPerson(personToMark, updatedPersonToMark);
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, deliveryStatus);
+
+        assertCommandFailure(markCommand, model, MESSAGE_RETURN_STATUS_CHANGED);
+    }
+
+    @Test
+    public void execute_markDoneOnReturnedDelivery_failed() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.DONE;
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPersonToMark = new PersonBuilder(personToMark)
+                .withDeliveryStatus(DeliveryStatus.RETURN)
+                .withNoOfDeliveryAttempts(DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN)
+                .build();
+
+        model.setPerson(personToMark, updatedPersonToMark);
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, deliveryStatus);
+
+        assertCommandFailure(markCommand, model, MESSAGE_RETURN_STATUS_CHANGED);
+    }
+
+    @Test
+    public void execute_markFailedOnReturnedDelivery_failed() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.FAILED;
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPersonToMark = new PersonBuilder(personToMark)
+                .withDeliveryStatus(DeliveryStatus.RETURN)
+                .withNoOfDeliveryAttempts(DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN)
+                .build();
+
+        model.setPerson(personToMark, updatedPersonToMark);
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, deliveryStatus);
+
+        assertCommandFailure(markCommand, model, MESSAGE_RETURN_STATUS_CHANGED);
+    }
+
+    @Test
+    public void execute_markPendingOnReturnedDelivery_failed() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.OTW;
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPersonToMark = new PersonBuilder(personToMark)
+                .withDeliveryStatus(DeliveryStatus.RETURN)
+                .withNoOfDeliveryAttempts(DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN)
+                .build();
+
+        model.setPerson(personToMark, updatedPersonToMark);
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, deliveryStatus);
+
+        assertCommandFailure(markCommand, model, MESSAGE_RETURN_STATUS_CHANGED);
+    }
+
+    @Test
+    public void execute_markReturnOnReturnedDelivery_failed() {
+        DeliveryStatus deliveryStatus = DeliveryStatus.RETURN;
+
+        Person personToMark = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person updatedPersonToMark = new PersonBuilder(personToMark)
+                .withDeliveryStatus(DeliveryStatus.RETURN)
+                .withNoOfDeliveryAttempts(DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN)
+                .build();
+
+        model.setPerson(personToMark, updatedPersonToMark);
+        MarkCommand markCommand = new MarkCommand(INDEX_FIRST_PERSON, deliveryStatus);
+
+        assertCommandFailure(markCommand, model, MESSAGE_RETURN_STATUS_CHANGED);
     }
 
     @Test

--- a/src/test/java/bookopedia/logic/commands/SortCommandTest.java
+++ b/src/test/java/bookopedia/logic/commands/SortCommandTest.java
@@ -24,7 +24,7 @@ import bookopedia.model.person.Person;
 class SortCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private final List<Person> sortedList = Arrays.asList(DANIEL, ELLE, FIONA, GEORGE, BENSON, CARL, ALICE);
+    private final List<Person> sortedList = Arrays.asList(DANIEL, ELLE, FIONA, BENSON, CARL, ALICE, GEORGE);
 
     @Test
     public void executeSort() {

--- a/src/test/java/bookopedia/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/bookopedia/logic/parser/MarkCommandParserTest.java
@@ -172,4 +172,34 @@ public class MarkCommandParserTest {
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
+
+    @Test
+    public void parse_lowercaseReturn_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + " " + CliSyntax.PREFIX_STATUS + "return";
+
+        MarkCommand expectedCommand = new MarkCommand(targetIndex, DeliveryStatus.RETURN);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_mixedcaseReturn_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + " " + CliSyntax.PREFIX_STATUS + "reTUrn";
+
+        MarkCommand expectedCommand = new MarkCommand(targetIndex, DeliveryStatus.RETURN);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_uppercaseReturn_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + " " + CliSyntax.PREFIX_STATUS + "RETURN";
+
+        MarkCommand expectedCommand = new MarkCommand(targetIndex, DeliveryStatus.RETURN);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
 }

--- a/src/test/java/bookopedia/model/AddressBookTest.java
+++ b/src/test/java/bookopedia/model/AddressBookTest.java
@@ -93,7 +93,7 @@ public class AddressBookTest {
     public void sortAddressBook() {
         addressBook.setPersons(getTypicalPersons());
         addressBook.sort();
-        assertEquals(addressBook.getPersonList(), Arrays.asList(DANIEL, ELLE, FIONA, GEORGE, BENSON, CARL, ALICE));
+        assertEquals(addressBook.getPersonList(), Arrays.asList(DANIEL, ELLE, FIONA, BENSON, CARL, ALICE, GEORGE));
     }
 
     /**

--- a/src/test/java/bookopedia/model/ModelManagerTest.java
+++ b/src/test/java/bookopedia/model/ModelManagerTest.java
@@ -146,6 +146,6 @@ public class ModelManagerTest {
         modelManager.setAddressBook(getTypicalAddressBook());
         modelManager.sort();
         assertEquals(modelManager.getAddressBook().getPersonList(),
-                Arrays.asList(DANIEL, ELLE, FIONA, GEORGE, BENSON, CARL, ALICE));
+                Arrays.asList(DANIEL, ELLE, FIONA, BENSON, CARL, ALICE, GEORGE));
     }
 }

--- a/src/test/java/bookopedia/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/bookopedia/storage/JsonAdaptedPersonTest.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import bookopedia.commons.exceptions.IllegalValueException;
+import bookopedia.model.DeliveryStatus;
 import bookopedia.model.person.Address;
 import bookopedia.model.person.Email;
 import bookopedia.model.person.Name;
@@ -25,7 +26,9 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_DELIVERY_STATUS = "HUH";
-    private static final int INVALID_NO_OF_DELIVERY_ATTEMPTS = -1;
+    private static final int INVALID_NO_OF_DELIVERY_ATTEMPTS_NEGATIVE = -1;
+
+    private static final int INVALID_NO_OF_DELIVERY_ATTEMPTS_OVER = DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN + 1;
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -43,7 +46,7 @@ public class JsonAdaptedPersonTest {
             .map(JsonAdaptedParcelIsBulky::new)
             .collect(Collectors.toList());
     private static final String VALID_DELIVERY_STATUS = "PENDING";
-    private static final int VALID_NO_OF_DELIVERY_ATTEMPTS = 1;
+    private static final int VALID_NO_OF_DELIVERY_ATTEMPTS = DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN;
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -160,10 +163,26 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
-    public void toModelType_invalidNoOfDeliveryAttempts_throwsIllegalValueException() {
+    public void toModelType_invalidNoOfDeliveryAttemptsNegative_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS, VALID_TAGS, VALID_FRAGILE, VALID_BULKY,
-                VALID_DELIVERY_STATUS, INVALID_NO_OF_DELIVERY_ATTEMPTS);
+                VALID_DELIVERY_STATUS, INVALID_NO_OF_DELIVERY_ATTEMPTS_NEGATIVE);
+        assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidNoOfDeliveryAttemptsOver_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_TAGS, VALID_FRAGILE, VALID_BULKY,
+                VALID_DELIVERY_STATUS, INVALID_NO_OF_DELIVERY_ATTEMPTS_OVER);
+        assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_deliveryAttemptsMismatchDeliveryStatusReturn_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS, VALID_TAGS, VALID_FRAGILE, VALID_BULKY,
+                DeliveryStatus.FAILED.toString(), DeliveryStatus.NO_OF_ATTEMPTS_BEFORE_RETURN);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 }

--- a/src/test/java/bookopedia/testutil/TypicalIndexes.java
+++ b/src/test/java/bookopedia/testutil/TypicalIndexes.java
@@ -9,4 +9,5 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_SEVENTH_PERSON = Index.fromOneBased(7);
 }

--- a/src/test/java/bookopedia/testutil/TypicalPersons.java
+++ b/src/test/java/bookopedia/testutil/TypicalPersons.java
@@ -42,7 +42,8 @@ public class TypicalPersons {
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withAddress("4th street")
+            .withDeliveryStatus(DeliveryStatus.FAILED).build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")


### PR DESCRIPTION
Closes #90.

![image](https://user-images.githubusercontent.com/70547991/228426022-b7836785-b46c-4993-9c05-c7a371471e34.png)

The number of attempts required before a delivery is marked as RETURN is set to 3.

Delivery rider can also set a delivery to RETURN manually if recipient rejects.
