### PR TITLE
Lock marking of done deliveries

### DIFF
--- a/src/main/java/bookopedia/logic/commands/MarkCommand.java
+++ b/src/main/java/bookopedia/logic/commands/MarkCommand.java
@@ -21,9 +21,8 @@ public class MarkCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Mark delivery status for a person. "
             + "Parameters: INDEX (must be a positive integer) "
             + CliSyntax.PREFIX_STATUS + "STATUS (pending/otw/done/failed/return)";
-
     public static final String MESSAGE_RETURN_STATUS_CHANGED = "Cannot change status of a return delivery!";
-
+    public static final String MESSAGE_DONE_STATUS_CHANGED = "Cannot change status of a done delivery!";
     public static final String MESSAGE_SUCCESS = "Marked %1$s's delivery as: %2$s";
 
     private final Index targetIndex;
@@ -55,6 +54,8 @@ public class MarkCommand extends Command {
 
         if (personToMark.getDeliveryStatus() == DeliveryStatus.RETURN) {
             throw new CommandException(MESSAGE_RETURN_STATUS_CHANGED);
+        } else if (personToMark.getDeliveryStatus() == DeliveryStatus.DONE) {
+            throw new CommandException(MESSAGE_DONE_STATUS_CHANGED);
         }
 
         int noOfDeliveryAttemptsToSet = personToMark.getNoOfDeliveryAttempts();


### PR DESCRIPTION
Closes #92.

Prevent done deliveries from having its status from being changed.

![image](https://user-images.githubusercontent.com/70547991/228428359-626f55d8-2be6-42b2-9d0e-e0a60149b4bd.png)
