### PR TITLE
Prevent done and return deliveries from being modified by commands

### DIFF
--- a/src/main/java/bookopedia/logic/commands/AddParcelCommand.java
+++ b/src/main/java/bookopedia/logic/commands/AddParcelCommand.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import bookopedia.commons.core.index.Index;
 import bookopedia.logic.commands.exceptions.CommandException;
 import bookopedia.logic.parser.CliSyntax;
+import bookopedia.model.DeliveryStatus;
 import bookopedia.model.Model;
 import bookopedia.model.parcel.Parcel;
 import bookopedia.model.person.Person;
@@ -24,7 +25,8 @@ public class AddParcelCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds parcel to an existing person. "
             + "Parameters: INDEX (must be a positive integer) "
             + CliSyntax.PREFIX_PARCEL + "PARCEL (must be alphanumeric) ";
-
+    public static final String MESSAGE_RETURN_STATUS_ADD_PC = "Cannot add parcel to a return delivery!";
+    public static final String MESSAGE_DONE_STATUS_ADD_PC = "Cannot add parcel to a done delivery!";
     public static final String MESSAGE_SUCCESS = "Added %1$s to %2$s's delivery";
 
     private final Index targetIndex;
@@ -51,6 +53,12 @@ public class AddParcelCommand extends Command {
         }
 
         Person personToAddParcel = lastShownList.get(targetIndex.getZeroBased());
+
+        if (personToAddParcel.getDeliveryStatus() == DeliveryStatus.RETURN) {
+            throw new CommandException(MESSAGE_RETURN_STATUS_ADD_PC);
+        } else if (personToAddParcel.getDeliveryStatus() == DeliveryStatus.DONE) {
+            throw new CommandException(MESSAGE_DONE_STATUS_ADD_PC);
+        }
 
         final Set<Parcel> updatedParcels = new HashSet<>();
         updatedParcels.addAll(personToAddParcel.getParcels());

--- a/src/main/java/bookopedia/logic/commands/EditCommand.java
+++ b/src/main/java/bookopedia/logic/commands/EditCommand.java
@@ -46,6 +46,8 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_RETURN_STATUS_EDIT = "Cannot edit a return delivery!";
+    public static final String MESSAGE_DONE_STATUS_EDIT = "Cannot edit a done delivery!";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -72,6 +74,13 @@ public class EditCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        if (personToEdit.getDeliveryStatus() == DeliveryStatus.RETURN) {
+            throw new CommandException(MESSAGE_RETURN_STATUS_EDIT);
+        } else if (personToEdit.getDeliveryStatus() == DeliveryStatus.DONE) {
+            throw new CommandException(MESSAGE_DONE_STATUS_EDIT);
+        }
+
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {

--- a/src/main/java/bookopedia/logic/commands/MarkParcelCommand.java
+++ b/src/main/java/bookopedia/logic/commands/MarkParcelCommand.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import bookopedia.commons.core.index.Index;
 import bookopedia.logic.commands.exceptions.CommandException;
 import bookopedia.logic.parser.CliSyntax;
+import bookopedia.model.DeliveryStatus;
 import bookopedia.model.Model;
 import bookopedia.model.ParcelStatus;
 import bookopedia.model.parcel.Parcel;
@@ -30,7 +31,8 @@ public class MarkParcelCommand extends Command {
             + "\nParameters: INDEX of Delivery (a positive integer) "
             + CliSyntax.PREFIX_PARCEL + "INDEX of Parcel (a positive integer within list) "
             + CliSyntax.PREFIX_STATUS + "STATUS (fragile/bulky)";
-
+    public static final String MESSAGE_RETURN_STATUS_MARK_PC = "Cannot mark parcel in a return delivery!";
+    public static final String MESSAGE_DONE_STATUS_MARK_PC = "Cannot mark parcel in a done delivery!";
     public static final String MESSAGE_SUCCESS = "Marked %1$s's parcel %2$s as %3$s";
 
     private final Index targetIndex;
@@ -60,6 +62,12 @@ public class MarkParcelCommand extends Command {
             throw new CommandException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
         Person targetPerson = lastShownList.get(targetIndex.getZeroBased());
+
+        if (targetPerson.getDeliveryStatus() == DeliveryStatus.RETURN) {
+            throw new CommandException(MESSAGE_RETURN_STATUS_MARK_PC);
+        } else if (targetPerson.getDeliveryStatus() == DeliveryStatus.DONE) {
+            throw new CommandException(MESSAGE_DONE_STATUS_MARK_PC);
+        }
 
         // No parcels
         if (targetPerson.getParcels().size() == 0) {

--- a/src/test/java/bookopedia/logic/commands/AddParcelCommandTest.java
+++ b/src/test/java/bookopedia/logic/commands/AddParcelCommandTest.java
@@ -1,10 +1,14 @@
 package bookopedia.logic.commands;
 
+import static bookopedia.logic.commands.AddParcelCommand.MESSAGE_DONE_STATUS_ADD_PC;
+import static bookopedia.logic.commands.AddParcelCommand.MESSAGE_RETURN_STATUS_ADD_PC;
 import static bookopedia.logic.commands.CommandTestUtil.VALID_PARCEL_LAZADA;
 import static bookopedia.logic.commands.CommandTestUtil.VALID_PARCEL_SHOPEE;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandFailure;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static bookopedia.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static bookopedia.testutil.TypicalPersons.ALICE;
+import static bookopedia.testutil.TypicalPersons.AMY;
 import static bookopedia.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.HashSet;
@@ -15,11 +19,13 @@ import org.junit.jupiter.api.Test;
 import bookopedia.commons.core.Messages;
 import bookopedia.commons.core.index.Index;
 import bookopedia.model.AddressBook;
+import bookopedia.model.DeliveryStatus;
 import bookopedia.model.Model;
 import bookopedia.model.ModelManager;
 import bookopedia.model.UserPrefs;
 import bookopedia.model.parcel.Parcel;
 import bookopedia.model.person.Person;
+import bookopedia.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for AddParcelCommand.
@@ -72,4 +78,29 @@ public class AddParcelCommandTest {
         assertCommandFailure(addParcelCommand, model, String.format(Messages.MESSAGE_EXISTING_PARCEL, existingParcel));
     }
 
+    @Test
+    public void execute_addParcelOnDoneDelivery_failure() {
+        Person personDone = new PersonBuilder(AMY).withDeliveryStatus(DeliveryStatus.DONE)
+                .withParcels("Parcel1").build();
+        model.addPerson(personDone);
+        Index personToMarkIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        AddParcelCommand addParcelCommand = new AddParcelCommand(personToMarkIndex, new Parcel("Parcel2"));
+
+        assertCommandFailure(addParcelCommand, model,
+                String.format(MESSAGE_DONE_STATUS_ADD_PC, ALICE.getName()));
+    }
+
+    @Test
+    public void execute_addParcelOnReturnDelivery_failure() {
+        Person personDone = new PersonBuilder(AMY).withDeliveryStatus(DeliveryStatus.RETURN)
+                .withParcels("Parcel1").build();
+        model.addPerson(personDone);
+        Index personToMarkIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        AddParcelCommand addParcelCommand = new AddParcelCommand(personToMarkIndex, new Parcel("Parcel2"));
+
+        assertCommandFailure(addParcelCommand, model,
+                String.format(MESSAGE_RETURN_STATUS_ADD_PC, ALICE.getName()));
+    }
 }

--- a/src/test/java/bookopedia/logic/commands/EditCommandTest.java
+++ b/src/test/java/bookopedia/logic/commands/EditCommandTest.java
@@ -9,8 +9,12 @@ import static bookopedia.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandFailure;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static bookopedia.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static bookopedia.logic.commands.EditCommand.MESSAGE_DONE_STATUS_EDIT;
+import static bookopedia.logic.commands.EditCommand.MESSAGE_RETURN_STATUS_EDIT;
 import static bookopedia.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static bookopedia.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static bookopedia.testutil.TypicalPersons.ALICE;
+import static bookopedia.testutil.TypicalPersons.AMY;
 import static bookopedia.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -144,6 +148,32 @@ public class EditCommandTest {
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_editDoneDelivery_failure() {
+        Person personDone = new PersonBuilder(AMY).withDeliveryStatus(DeliveryStatus.DONE)
+                .withParcels("Parcel1").build();
+        model.addPerson(personDone);
+        Index personToMarkIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        EditCommand editCommand = new EditCommand(personToMarkIndex, new EditPersonDescriptor());
+
+        assertCommandFailure(editCommand, model,
+                String.format(MESSAGE_DONE_STATUS_EDIT, ALICE.getName()));
+    }
+
+    @Test
+    public void execute_editReturnDelivery_failure() {
+        Person personDone = new PersonBuilder(AMY).withDeliveryStatus(DeliveryStatus.RETURN)
+                .withParcels("Parcel1").build();
+        model.addPerson(personDone);
+        Index personToMarkIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        EditCommand editCommand = new EditCommand(personToMarkIndex, new EditPersonDescriptor());
+
+        assertCommandFailure(editCommand, model,
+                String.format(MESSAGE_RETURN_STATUS_EDIT, ALICE.getName()));
     }
 
     @Test

--- a/src/test/java/bookopedia/logic/commands/MarkParcelCommandTest.java
+++ b/src/test/java/bookopedia/logic/commands/MarkParcelCommandTest.java
@@ -5,9 +5,12 @@ import static bookopedia.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_
 import static bookopedia.commons.core.Messages.MESSAGE_NO_PARCELS;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandFailure;
 import static bookopedia.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static bookopedia.logic.commands.MarkParcelCommand.MESSAGE_DONE_STATUS_MARK_PC;
+import static bookopedia.logic.commands.MarkParcelCommand.MESSAGE_RETURN_STATUS_MARK_PC;
 import static bookopedia.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static bookopedia.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static bookopedia.testutil.TypicalPersons.ALICE;
+import static bookopedia.testutil.TypicalPersons.AMY;
 import static bookopedia.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -16,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import bookopedia.commons.core.index.Index;
 import bookopedia.model.AddressBook;
+import bookopedia.model.DeliveryStatus;
 import bookopedia.model.Model;
 import bookopedia.model.ModelManager;
 import bookopedia.model.ParcelStatus;
@@ -95,6 +99,34 @@ public class MarkParcelCommandTest {
                 ParcelStatus.FRAGILE);
 
         assertCommandFailure(markParcelCommand, expectedModel, String.format(MESSAGE_NO_PARCELS, ALICE.getName()));
+    }
+
+    @Test
+    public void execute_markParcelOnDoneDelivery_failure() {
+        Person personDone = new PersonBuilder(AMY).withDeliveryStatus(DeliveryStatus.DONE)
+                .withParcels("Parcel1").build();
+        model.addPerson(personDone);
+        Index personToMarkIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        MarkParcelCommand markParcelCommand = new MarkParcelCommand(personToMarkIndex, Index.fromOneBased(1),
+                ParcelStatus.FRAGILE);
+
+        assertCommandFailure(markParcelCommand, model,
+                String.format(MESSAGE_DONE_STATUS_MARK_PC, ALICE.getName()));
+    }
+
+    @Test
+    public void execute_markParcelOnReturnDelivery_failure() {
+        Person personDone = new PersonBuilder(AMY).withDeliveryStatus(DeliveryStatus.RETURN)
+                .withParcels("Parcel1").build();
+        model.addPerson(personDone);
+        Index personToMarkIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        MarkParcelCommand markParcelCommand = new MarkParcelCommand(personToMarkIndex, Index.fromOneBased(1),
+                ParcelStatus.FRAGILE);
+
+        assertCommandFailure(markParcelCommand, model,
+                String.format(MESSAGE_RETURN_STATUS_MARK_PC, ALICE.getName()));
     }
 
     @Test


### PR DESCRIPTION
Closes #123.

Done and Return deliveries should not have their parcels or information edited once marked done or return.